### PR TITLE
Fixes #31703 - Switch Container Gateway to SQLite

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-20.04
-    services:
-      postgres:
-        image: postgres:12
-        env:
-          POSTGRES_USER: smart_proxy_container_gateway_test_user
-          POSTGRES_PASSWORD: smart_proxy_container_gateway_test_password
-          POSTGRES_DB: smart_proxy_container_gateway_test
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ npm-debug.log
 /foreman/
 package-lock.json
 webpack/foremanReact/
+*.db
+.vendor/

--- a/README.md
+++ b/README.md
@@ -33,39 +33,20 @@ The Container Gateway plugin requires a Pulp 3 instance to connect to.  Related 
 :pulp_client_ssl_key: 'Path to RSA private key for the Pulp certificate'
 ```
 
-# Database configuration
+# Database information
 
-The Container Gateway plugin assumes that PostgreSQL is installed on the system since Katello + Pulp 3 is a requirement.
-
-For a manual installation, which is currently the only installation method, a database must be created with the name
-`smart_proxy_container_gateway`.  There must also be a PostgreSQL user who has full access to this database. Related configuration options:
-```
-:postgres_db_hostname: 'localhost'
-:postgres_db_username: 'db_user'
-:postgres_db_password: 'password'
-```
-
-Database migrations are completely automated.  The plugin checks if the database is up-to-date before each query.
+SQLite database migrations are completely automated.  The plugin checks if the database is up-to-date before each query.
 
 # Katello interaction
 
-Auth information is retrieved from the Katello server during smart proxy sync time and cached in the PostgreSQL database.
+Auth information is retrieved from the Katello server during smart proxy sync time and cached in the SQLite database.
+
+Logging in with a container client will cause the Container Gateway to fetch a token from Katello using the login information.
 
 # Testing
 
-Running the full test suite requires setting up the test PostgreSQL database.  Create the test database with the following configuration:
-
-- Database name: `smart_proxy_container_gateway_test`
-- Database user: `smart_proxy_container_gateway_test_user`
-- Database user password: `smart_proxy_container_gateway_test_password`
-
-The database user must have full access to the test DB.  These postgresql commands will set it up:  
 ```
-# sudo -u postgres psql
-```
+bundle exec rubocop
 
-```
-create role smart_proxy_container_gateway_test_user with login;
-alter role smart_proxy_container_gateway_test_user password 'smart_proxy_container_gateway_test_password';
-create database smart_proxy_container_gateway_test owner = smart_proxy_container_gateway_test_user;
+bundle exec rake test
 ```

--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -6,8 +6,8 @@ module Proxy
       plugin 'container_gateway', Proxy::ContainerGateway::VERSION
 
       default_settings :pulp_endpoint => "https://#{`hostname`.strip}",
-                       :postgres_db_name => 'smart_proxy_container_gateway',
-                       :katello_registry_path => '/v2/'
+                       :katello_registry_path => '/v2/',
+                       :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
 
       http_rackup_path File.expand_path('smart_proxy_container_gateway/container_gateway_http_config.ru',
                                         File.expand_path('..', __dir__))

--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -3,7 +3,7 @@ require 'smart_proxy_container_gateway/container_gateway'
 require 'smart_proxy_container_gateway/container_gateway_main'
 require 'smart_proxy_container_gateway/foreman_api'
 require 'sequel'
-require 'pg'
+require 'sqlite3'
 
 module Proxy
   module ContainerGateway

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -100,10 +100,7 @@ module Proxy
       end
 
       def initialize_db
-        conn = Sequel.postgres(host: Proxy::ContainerGateway::Plugin.settings.postgres_db_hostname,
-                               user: Proxy::ContainerGateway::Plugin.settings.postgres_db_username,
-                               password: Proxy::ContainerGateway::Plugin.settings.postgres_db_password,
-                               database: Proxy::ContainerGateway::Plugin.settings.postgres_db_name)
+        conn = Sequel.connect("sqlite://#{Proxy::ContainerGateway::Plugin.settings.sqlite_db_path}")
         container_gateway_path = $LOAD_PATH.detect { |path| path.include? 'smart_proxy_container_gateway' }
         begin
           Sequel::Migrator.check_current(conn, "#{container_gateway_path}/smart_proxy_container_gateway/sequel_migrations")

--- a/settings.d/container_gateway.yml.example
+++ b/settings.d/container_gateway.yml.example
@@ -3,7 +3,4 @@
 :pulp_endpoint: 'https://your_pulp_3_server_here.com'
 :pulp_client_ssl_cert: 'X509 certificate for authenticating with Pulp'
 :pulp_client_ssl_key: 'RSA private key for the Pulp certificate'
-:postgres_db_hostname: 'localhost'
-:postgres_db_name: 'smart_proxy_container_gateway'
-:postgres_db_username: 'db_user'
-:postgres_db_password: 'password'
+:sqlite_db_path: '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'

--- a/smart_proxy_container_gateway.gemspec
+++ b/smart_proxy_container_gateway.gemspec
@@ -15,6 +15,6 @@ Gem::Specification.new do |s|
   s.license = 'GPLv3'
 
   s.required_ruby_version = '~> 2.5'
-  s.add_dependency 'pg'
   s.add_dependency 'sequel'
+  s.add_dependency 'sqlite3'
 end

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -18,10 +18,7 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
                                                        :katello_registry_path => '/v2/',
                                                        :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
                                                        :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
-                                                       :postgres_db_username => 'smart_proxy_container_gateway_test_user',
-                                                       :postgres_db_password => 'smart_proxy_container_gateway_test_password',
-                                                       :postgres_db_name => 'smart_proxy_container_gateway_test',
-                                                       :postgres_db_hostname => 'localhost')
+                                                       :sqlite_db_path => 'container_gateway_test.db')
   end
 
   def test_ping_v1

--- a/test/container_gateway_backend_test.rb
+++ b/test/container_gateway_backend_test.rb
@@ -17,10 +17,7 @@ class ContainerGatewayBackendTest < Test::Unit::TestCase
     Proxy::ContainerGateway::Plugin.load_test_settings(:pulp_endpoint => 'https://test.example.com',
                                                        :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
                                                        :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
-                                                       :postgres_db_username => 'smart_proxy_container_gateway_test_user',
-                                                       :postgres_db_password => 'smart_proxy_container_gateway_test_password',
-                                                       :postgres_db_name => 'smart_proxy_container_gateway_test',
-                                                       :postgres_db_hostname => 'localhost')
+                                                       :sqlite_db_path => 'container_gateway_test.db')
   end
 
   def teardown


### PR DESCRIPTION
SQLite is now the database of choice due to added complexity that PostgreSQL brought.

To test, try doing actions that use the database like updating the unauthenticated repo list or `podman login`.