### PR TITLE
Fixes #31721 - unauth tokens have bad timestamp

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -72,8 +72,8 @@ module Proxy
 
         unless auth_header.present? && auth_header.basic_auth?
           one_year = (60 * 60 * 24 * 365)
-          return { token: AuthorizationHeader::UNAUTHORIZED_TOKEN, issued_at: Time.now,
-expires_at: Time.now + one_year }.to_json
+          return { token: AuthorizationHeader::UNAUTHORIZED_TOKEN, issued_at: Time.now.iso8601,
+                   expires_at: (Time.now + one_year).iso8601 }.to_json
         end
 
         token_response = ForemanApi.new.fetch_token(auth_header.raw_header, request.params)

--- a/lib/smart_proxy_container_gateway/version.rb
+++ b/lib/smart_proxy_container_gateway/version.rb
@@ -1,5 +1,5 @@
 module Proxy
   module ContainerGateway
-    VERSION = '1.0.0'.freeze
+    VERSION = '1.0.1'.freeze
   end
 end


### PR DESCRIPTION
To test:

Try `podman search ...` without logging in. 