### PR TITLE
Use more effective methods for concise code

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,5 @@ group :development do
 end
 
 # load local gemfile
-local_gemfile = File.join(File.dirname(__FILE__), 'Gemfile.local.rb')
+local_gemfile = File.join(__dir__, 'Gemfile.local.rb')
 instance_eval(Bundler.read_file(local_gemfile)) if File.exist?(local_gemfile)

--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -9,10 +9,7 @@ module Proxy
                        :katello_registry_path => '/v2/',
                        :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
 
-      http_rackup_path File.expand_path('smart_proxy_container_gateway/container_gateway_http_config.ru',
-                                        File.expand_path('..', __dir__))
-      https_rackup_path File.expand_path('smart_proxy_container_gateway/container_gateway_http_config.ru',
-                                         File.expand_path('..', __dir__))
+      rackup_path File.join(__dir__, 'container_gateway_http_config.ru')
     end
   end
 end

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -117,12 +117,12 @@ module Proxy
       end
 
       def pulp_cert
-        OpenSSL::X509::Certificate.new(File.open(Proxy::ContainerGateway::Plugin.settings.pulp_client_ssl_cert, 'r').read)
+        OpenSSL::X509::Certificate.new(File.read(Proxy::ContainerGateway::Plugin.settings.pulp_client_ssl_cert))
       end
 
       def pulp_key
         OpenSSL::PKey::RSA.new(
-          File.open(Proxy::ContainerGateway::Plugin.settings.pulp_client_ssl_key, 'r').read
+          File.read(Proxy::ContainerGateway::Plugin.settings.pulp_client_ssl_key)
         )
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,4 @@
 require 'test/unit'
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
+$LOAD_PATH << File.join(__dir__, '..', 'lib')
 
 require 'smart_proxy_for_testing'


### PR DESCRIPTION
This uses __dir__ and File.read where possible. It also uses the rackup_path method introduced in Smart Proxy 2.3.