### PR TITLE
Fixes #31759 - Make the CA configurable and add default certs

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -10,6 +10,7 @@ module Proxy
     class << self
       def pulp_registry_request(uri)
         http_client = Net::HTTP.new(uri.host, uri.port)
+        http_client.ca_file = pulp_ca
         http_client.cert = pulp_cert
         http_client.key = pulp_key
         http_client.use_ssl = true
@@ -114,6 +115,10 @@ module Proxy
 
       def migrate_db(db_connection, container_gateway_path)
         Sequel::Migrator.run(db_connection, "#{container_gateway_path}/smart_proxy_container_gateway/sequel_migrations")
+      end
+
+      def pulp_ca
+        Proxy::ContainerGateway::Plugin.settings.pulp_client_ssl_ca
       end
 
       def pulp_cert

--- a/lib/smart_proxy_container_gateway/version.rb
+++ b/lib/smart_proxy_container_gateway/version.rb
@@ -1,5 +1,5 @@
 module Proxy
   module ContainerGateway
-    VERSION = '1.0.1'.freeze
+    VERSION = '1.0.2'.freeze
   end
 end

--- a/settings.d/container_gateway.yml.example
+++ b/settings.d/container_gateway.yml.example
@@ -1,6 +1,8 @@
 ---
 :enabled: true
 :pulp_endpoint: 'https://your_pulp_3_server_here.com'
+:pulp_client_ssl_ca: 'CA Cert for authenticating with Pulp'
 :pulp_client_ssl_cert: 'X509 certificate for authenticating with Pulp'
 :pulp_client_ssl_key: 'RSA private key for the Pulp certificate'
+:katello_registry_path: 'Katello container registry suffix, e.g., /v2/'
 :sqlite_db_path: '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'


### PR DESCRIPTION
The CA cert is now configurable and the container gateway defaults to the main proxy certs for talking with Pulp.