### PR TITLE
Fixes #31982 - Correct settings handling

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -5,21 +5,23 @@ module Proxy
     class Plugin < ::Proxy::Plugin
       plugin 'container_gateway', Proxy::ContainerGateway::VERSION
 
-      begin
-        SETTINGS = Proxy::Settings.initialize_global_settings
+      default_settings :pulp_endpoint => "https://#{`hostname`.strip}",
+                       :katello_registry_path => '/v2/',
+                       :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
 
-        default_settings :pulp_endpoint => "https://#{`hostname`.strip}",
-                         :pulp_client_ssl_ca => SETTINGS.foreman_ssl_ca,
-                         :pulp_client_ssl_cert => SETTINGS.foreman_ssl_cert,
-                         :pulp_client_ssl_key => SETTINGS.foreman_ssl_key,
-                         :katello_registry_path => '/v2/',
-                         :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
-      rescue Errno::ENOENT
-        logger.warn("Default settings could not be loaded.  Default certs will not be set.")
-        default_settings :pulp_endpoint => "https://#{`hostname`.strip}",
-                         :katello_registry_path => '/v2/',
-                         :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+      # Load defaults that copy values from SETTINGS. This is done as
+      # programmable settings since SETTINGS isn't initialized during plugin
+      # loading.
+      load_programmable_settings do |settings|
+        settings[:pulp_client_ssl_ca] ||= SETTINGS.foreman_ssl_ca
+        settings[:pulp_client_ssl_cert] ||= SETTINGS.foreman_ssl_cert
+        settings[:pulp_client_ssl_key] ||= SETTINGS.foreman_ssl_key
       end
+
+      # TODO: sqlite_db_path should able be readable or creatable. There's no
+      # test for creatable
+      validate_readable :pulp_client_ssl_ca, :pulp_client_ssl_cert, :pulp_client_ssl_key
+      validate :pulp_endpoint, url: true
 
       rackup_path File.join(__dir__, 'container_gateway_http_config.ru')
     end

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -1,0 +1,34 @@
+require 'tempfile'
+require 'json'
+
+require 'test_helper'
+require 'root/root_v2_api'
+require 'smart_proxy_container_gateway/container_gateway'
+
+class ContainerGatewayApiFeaturesTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
+    Proxy::RootV2Api.new
+  end
+
+  def test_features
+    db_path = Tempfile.new
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file)
+                              .with('container_gateway.yml')
+                              .returns(enabled: true, sqlite_db_path: db_path)
+
+    get '/features'
+
+    response = JSON.parse(last_response.body)
+
+    mod = response['container_gateway']
+    refute_nil(mod)
+    assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:container_gateway])
+    assert_equal([], mod['capabilities'])
+    assert_equal({}, mod['settings'])
+  ensure
+    File.unlink(db_path)
+  end
+end


### PR DESCRIPTION
This avoids the initialize_global_settings call which is wrong. That can have unexpected consequences. Instead, it uses the correct load_programmable_settings to handle it.

It also ensures all files are readable or errors out. The Pulp endpoint also needs to be a valid URL.

The only thing I don't know is if the database needs to be readable. I think it may also be able to create the file if the parent directory is writeable.