### PR TITLE
Use bundler-cache option of ruby/setup-ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.5
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true
     - name: Run Rubocop
       run: bundle exec rubocop
     - name: Run tests


### PR DESCRIPTION
This lets ruby/setup-ruby run bundle install. In addition to running it with multiple jobs it also caches the gems which makes the next CI run faster.