### PR TITLE
Fixes #32745 - proxy sync fails when there are no container repos

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -20,7 +20,7 @@ Metrics/BlockLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 118
+  Max: 312
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -123,7 +123,8 @@ module Proxy
       put '/repository_list/?' do
         do_authorize_any
 
-        ContainerGateway.update_repository_list(params['repositories'])
+        repositories = params['repositories'].nil? ? [] : params['repositories']
+        ContainerGateway.update_repository_list(repositories)
         {}
       end
 


### PR DESCRIPTION
To test:

1) Sync a smart proxy whose lifecycle environment has no container content.  Ensure this works.
2) Ensure that syncing smart proxies with container content still works too.  After syncing, `podman login ...` to the proxy and run `podman search ...` to see your container repo(s).