### PR TITLE
Fixes #33538 - Cannot pull images w/ `/`  in name

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -25,15 +25,19 @@ module Proxy
         end
       end
 
-      get '/v2/:repository/manifests/:tag/?' do
-        handle_repo_auth(params, auth_header, request)
-        redirection_location = Proxy::ContainerGateway.manifests(params[:repository], params[:tag])
+      get '/v2/*/manifests/*/?' do
+        repository = params[:splat][0]
+        tag = params[:splat][1]
+        handle_repo_auth(repository, auth_header, request)
+        redirection_location = Proxy::ContainerGateway.manifests(repository, tag)
         redirect to(redirection_location)
       end
 
-      get '/v2/:repository/blobs/:digest/?' do
-        handle_repo_auth(params, auth_header, request)
-        redirection_location = Proxy::ContainerGateway.blobs(params[:repository], params[:digest])
+      get '/v2/*/blobs/*/?' do
+        repository = params[:splat][0]
+        digest = params[:splat][1]
+        handle_repo_auth(repository, auth_header, request)
+        redirection_location = Proxy::ContainerGateway.blobs(repository, digest)
         redirect to(redirection_location)
       end
 
@@ -130,7 +134,7 @@ module Proxy
 
       private
 
-      def handle_repo_auth(params, auth_header, request)
+      def handle_repo_auth(repository, auth_header, request)
         user_token_is_valid = false
         # FIXME: Getting unauthenticated token here...
         if auth_header.present? && auth_header.valid_user_token?
@@ -139,7 +143,7 @@ module Proxy
         end
         username = request.params['account'] if username.nil?
 
-        return if Proxy::ContainerGateway.authorized_for_repo?(params[:repository], user_token_is_valid, username)
+        return if Proxy::ContainerGateway.authorized_for_repo?(repository, user_token_is_valid, username)
 
         redirect_authorization_headers
         halt 401, "unauthorized"

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -80,13 +80,13 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
     Proxy::ContainerGateway.expects(:authorized_for_repo?).returns(true)
     redirect_headers = {
       'location' => "#{::Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}" \
-                    "/pulp/container/test_repo/manifests/test_tag?validate_token=test_token"
+                    "/pulp/container/library/test_repo/manifests/test_tag?validate_token=test_token"
     }
     stub_request(:get, "#{::Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}" \
-                       "/pulpcore_registry/v2/test_repo/manifests/test_tag").
+                       "/pulpcore_registry/v2/library/test_repo/manifests/test_tag").
       to_return(:status => 302, :body => '', :headers => redirect_headers)
 
-    get '/v2/test_repo/manifests/test_tag'
+    get '/v2/library/test_repo/manifests/test_tag'
     assert last_response.redirect?, "Last response was not a redirect: #{last_response.body}"
     assert_equal('', last_response.body)
   end
@@ -94,12 +94,12 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
   def test_redirects_blob_request
     ::Proxy::ContainerGateway.expects(:authorized_for_repo?).returns(true)
     redirect_headers = { 'location' => "#{::Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}" \
-                                       "/pulp/container/test_repo/blobs/test_digest?validate_token=test_token" }
+                                       "/pulp/container/library/test_repo/blobs/test_digest?validate_token=test_token" }
     stub_request(:get, "#{::Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}" \
-                       "/pulpcore_registry/v2/test_repo/blobs/test_digest").
+                       "/pulpcore_registry/v2/library/test_repo/blobs/test_digest").
       to_return(:status => 302, :body => '', :headers => redirect_headers)
 
-    get '/v2/test_repo/blobs/test_digest'
+    get '/v2/library/test_repo/blobs/test_digest'
     assert last_response.redirect?, "Last response was not a redirect: #{last_response.body}"
     assert_equal('', last_response.body)
   end


### PR DESCRIPTION
Sinatra was thinking the slashes were URL delimiters because of how the routes for manifests and blobs were set up.  Now, `:splat` params are used to accept slashes.

To test:

1) Sync some container repo
2) Change environment registry naming pattern so that there are slashes in the `container_repository_name`
3) Sync that environment to a smart proxy
4) Try pulling the container image using podman or docker
5) See the error in the issue
6) Patch this PR into the smart_proxy_container_gateway code and try pulling again