### PR TITLE
[CP] Bump version to 1.0.6 and fix issue with user-repo mapping erroring on nil

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -92,6 +92,8 @@ module Proxy
         RepositoryUser.dataset.delete
         user_repo_maps['users'].each do |user_repo_map|
           user_repo_map.each do |user, repos|
+            next if repos.nil?
+
             repos.each do |repo|
               found_repo = Repository.find(name: repo['repository'],
                                            auth_required: repo['auth_required'].to_s.downcase == "true")

--- a/lib/smart_proxy_container_gateway/version.rb
+++ b/lib/smart_proxy_container_gateway/version.rb
@@ -1,5 +1,5 @@
 module Proxy
   module ContainerGateway
-    VERSION = '1.0.5'.freeze
+    VERSION = '1.0.6'.freeze
   end
 end


### PR DESCRIPTION
If a user syncs content to the container gateway, clears out all container repos, and then syncs again, they will get an error complaining about `nil` not supporting `each`.  This fixes that.  I'm also bumping the version up for an immediate release.