### PR TITLE
Fixes #35801 - list container image tags

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -41,6 +41,12 @@ module Proxy
         redirect to(redirection_location)
       end
 
+      get '/v2/*/tags/list/?' do
+        repository = params[:splat][0]
+        handle_repo_auth(repository, auth_header, request)
+        Proxy::ContainerGateway.tags(repository)
+      end
+
       get '/v1/search/?' do
         # Checks for podman client and issues a 404 in that case. Podman
         # examines the response from a /v1/search request. If the result

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -41,6 +41,13 @@ module Proxy
         pulp_registry_request(uri)['location']
       end
 
+      def tags(repository)
+        uri = URI.parse(
+          "#{Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}/pulpcore_registry/v2/#{repository}/tags/list"
+        )
+        pulp_registry_request(uri).body
+      end
+
       def v1_search(params = {})
         if params[:n].nil? || params[:n] == ""
           params[:n] = 25

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -76,6 +76,15 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
     assert last_response.unauthorized?
   end
 
+  def test_list_tags
+    Proxy::ContainerGateway.expects(:authorized_for_repo?).returns(true)
+    stub_request(:get, "#{::Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}" \
+                       "/pulpcore_registry/v2/library/test_repo/tags/list").
+      to_return(:status => 200, :body => "{\"repository\":\"library/test_repo\", \"tags\":[\"latest\"]}")
+    get '/v2/library/test_repo/tags/list'
+    assert_equal("{\"repository\":\"library/test_repo\", \"tags\":[\"latest\"]}", last_response.body)
+  end
+
   def test_redirects_manifest_request
     Proxy::ContainerGateway.expects(:authorized_for_repo?).returns(true)
     redirect_headers = {


### PR DESCRIPTION
Adds the `/tags/list` endpoint to support `skopeo inspect ...`.

To test:

1) Sync a container repository
2) Sync that repository to a smart proxy
3) `podman login proxy.example.com`
4) `podman search proxy.example.com/`
5) Choose one of the returned container images. Use the entire name with hostname and slashes.
6) `skopeo inspect docker://proxy.example.com/default_organization-production-container_view-product-quay_busybox --debug
7) See that something like the following is returned:

```
{
    "Name": "katello.example.com/default_organization-prod-container_view-product-quay_busybox",
    "Digest": "sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d",
    "RepoTags": [
        "latest"
    ],
    "Created": "2020-09-04T16:08:39.002329276Z",
    "DockerVersion": "",
    "Labels": null,
    "Architecture": "amd64",
    "Os": "linux",
    "Layers": [
        "sha256:9c075fe2c773108d2fe2c18ea170548b0ee30ef4e5e072d746e3f934e788b734",
        "sha256:ee780d08a5b4de5192a526d422987f451d9a065e6da42aefe8c3b20023a250c7"
    ],
    "Env": [
        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
        "TERM=xterm",
        "container=podman",
        "HOSTNAME="
    ]
}
```