### PR TITLE
Fixes #36616 - properly paginate /tags/list endpoint

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -35,7 +35,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ModuleLength:
-  Max: 160
+  Max: 170
 
 # Offense count: 1
 # Configuration parameters: IgnoredMethods.

--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -44,7 +44,15 @@ module Proxy
       get '/v2/*/tags/list/?' do
         repository = params[:splat][0]
         handle_repo_auth(repository, auth_header, request)
-        Proxy::ContainerGateway.tags(repository)
+        pulp_response = Proxy::ContainerGateway.tags(repository, params)
+        # "link"=>["<http://pulpcore-api/v2/container-image-name/tags/list?n=100&last=last-tag-name>; rel=\"next\""],
+        # https://docs.docker.com/registry/spec/api/#pagination-1
+        if pulp_response['link'].nil?
+          headers['link'] = ""
+        else
+          headers['link'] = pulp_response['link']
+        end
+        pulp_response.body
       end
 
       get '/v1/search/?' do

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -41,11 +41,18 @@ module Proxy
         pulp_registry_request(uri)['location']
       end
 
-      def tags(repository)
+      def tags(repository, params = {})
+        query = "?"
+        unless params[:n].nil? || params[:n] == ""
+          query = "#{query}n=#{params[:n]}"
+          query = "#{query}&" unless params[:last].nil?
+        end
+        query = "#{query}last=#{params[:last]}" unless params[:last].nil? || params[:last] == ""
+
         uri = URI.parse(
-          "#{Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}/pulpcore_registry/v2/#{repository}/tags/list"
+          "#{Proxy::ContainerGateway::Plugin.settings.pulp_endpoint}/pulpcore_registry/v2/#{repository}/tags/list#{query}"
         )
-        pulp_registry_request(uri).body
+        pulp_registry_request(uri)
       end
 
       def v1_search(params = {})


### PR DESCRIPTION
The tags list endpoint wasn't properly implementing pagination: https://docs.docker.com/registry/spec/api/#pagination-1

To test:

1) Sync jetstack/cert-manager-controller at quay.io
2) Sync that content to a smart proxy
3) Run: 

```
skopeo list-tags docker://smart-proxy.example.com/default_organization-development-container_view-product-jetstack_cert-manager-controller | grep '"' | wc -l
```
See that it returns less than the full amount of tags (something like 102 will be the count since Pulp by default limits the return to 100 tags).

4) Patch in my PR
5) Restart `foreman-proxy` and re-run the `skopeo` command
6) See now that 800 something tags are returned