### PR TITLE
Fixes #36771 - introduce sqlite timeout tuning

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -7,7 +7,8 @@ module Proxy
 
       default_settings :pulp_endpoint => "https://#{`hostname`.strip}",
                        :katello_registry_path => '/v2/',
-                       :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+                       :sqlite_db_path => '/var/lib/foreman-proxy/smart_proxy_container_gateway.db',
+                       :sqlite_timeout => 30_000
 
       # Load defaults that copy values from SETTINGS. This is done as
       # programmable settings since SETTINGS isn't initialized during plugin

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -174,7 +174,8 @@ module Proxy
 
       def initialize_db
         file_path = Proxy::ContainerGateway::Plugin.settings.sqlite_db_path
-        conn = Sequel.connect("sqlite://#{file_path}")
+        sqlite_timeout = Proxy::ContainerGateway::Plugin.settings.sqlite_timeout
+        conn = Sequel.connect("sqlite://#{file_path}", timeout: sqlite_timeout)
         container_gateway_path = $LOAD_PATH.detect { |path| path.include? 'smart_proxy_container_gateway' }
         begin
           Sequel::Migrator.check_current(conn, "#{container_gateway_path}/smart_proxy_container_gateway/sequel_migrations")

--- a/settings.d/container_gateway.yml.example
+++ b/settings.d/container_gateway.yml.example
@@ -6,3 +6,5 @@
 :pulp_client_ssl_key: 'RSA private key for the Pulp certificate'
 :katello_registry_path: 'Katello container registry suffix, e.g., /v2/'
 :sqlite_db_path: '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+# Database busy timeout in milliseconds
+:sqlite_timeout: 30000


### PR DESCRIPTION
Adds sqlite DB timeout tuning and bumps the default up to 30000 milliseconds. The `sequel` library's default is 5000 milliseconds.

The goal is to stop `SQLite3::BusyException` errors from happening so easily.

30000 is somewhat arbitrary -- 30 seconds should be long enough to serve massive sqlite transactions. It should also be a short enough period of time to catch any actual lockups that should report back as an error.

To test:

1) In Katello, sync 100 container repositories:
```
#!/bin/bash

for i in {1..100}
do
  hammer repository create --name "container-$i" --content-type docker --url https://quay.io --docker-upstream-name prometheus/busybox --download-policy on_demand --product-id 311
done
```

2) Sync those repositories to a smart proxy.

3) Open up two Foreman consoles and try overloading the database by constantly uploading new container repo information to the smart proxy:

```ruby
while 1 == 1 do
  ::SmartProxy.find(2).sync_container_gateway
end                
```

4) Try turning `sqlite_timeout` down to 1 to reproduce the error.

5) Try turning the `sqlite_timeout` up to 30000 to see the error go away.