### PR TITLE
Fixes #36827 - SP server can now handle Katello's new OAuth2 token format for container repos

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.7
         bundler-cache: true
     - name: Run Rubocop
       run: bundle exec rubocop

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 # Don't prefer is_a? over kind_of?
 Style/ClassCheck:

--- a/smart_proxy_container_gateway.gemspec
+++ b/smart_proxy_container_gateway.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.homepage = 'https://github.com/Katello/smart_proxy_container_gateway'
   s.license = 'GPLv3'
 
-  s.required_ruby_version = '~> 2.5'
+  s.required_ruby_version = '~> 2.7'
+  s.add_dependency 'activesupport'
   s.add_dependency 'sequel'
   s.add_dependency 'sqlite3'
 end

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -195,7 +195,8 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
     ::Proxy::SETTINGS.foreman_url = 'https://foreman'
     foreman_response = {
       "token": "imarealtoken",
-        "expires_at": DateTime.now + (2 / 24.0)
+      "issued_at": DateTime.now,
+      "expires_in": 180
     }
     stub_request(:get, "#{::Proxy::SETTINGS.foreman_url}/v2/token?account=foo").
       to_return(:body => foreman_response.to_json)


### PR DESCRIPTION
This PR references fixes for [this BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2229810).
These changes require running in conjunction with a Katello instance hosting [this PR](https://github.com/Katello/katello/pull/10768).

### Changes
This PR implements changes to authentication tokens which interact with docker repositories. Tokens are modified to 
- return [rfc3339-compatible](https://www.rfc-editor.org/rfc/rfc3339) datetime strings
- remove the 'expires_at' field
- add the 'expires_in' field, an integer representing the number of seconds after the 'issued_at' datetime the token will expire.

This should bring the issued auth tokens into compliance with [these docker specs](https://distribution.github.io/distribution/spec/auth/token/#requesting-a-token).

### Testing steps

1. Create a Katello instance linked to your smart proxy. On Katello, pull and launch [this PR](https://github.com/Katello/katello/pull/10768) if it hasn't been merged to master develop.
2. Create a product and add a valid docker repo. Add this product to a lifecycle environment.
4. Go to the lifecycle environment's details tab. Edit 'unauthenticated pull' and ensure it is marked 'No'.
5. Sync the smart proxy.
6. On the smart proxy, run `podman login <proxy hostname>`
7. Run `podman search <proxy hostname>/<repo>` to find your docker repo.
8. Copy the returned name into this command: `podman pull <name>`. There should be no errors.
9. Copy the image destination into `podman run <image dest>` to ensure everything worked.
10. On katello, edit the lifecycle environment's details tab to set 'unauthenticated pull' to 'Yes' and re-sync the smart proxy.
11. Re-run steps 7 through 9 to ensure unauthenticated pulls also function properly. You shouldn't need to log in.