### PR TITLE
Refactor settings to connection_string

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ The Container Gateway plugin requires a Pulp 3 instance to connect to.  Related 
 SQLite and PostgreSQL are supported, with SQLite being the default for development and testing.
 Use PostgreSQL in production for improved performance by adding the following settings:
 ```
-# Example PostgreSQL connection settings (default port is 5432)
-:database_backend: postgresql
-:postgresql_connection_string: postgres://foreman-proxy:changeme@localhost:5432/container_gateway
+# Example PostgreSQL connection settings, using UNIX socket and ident auth
+:db_connection_string: postgres:///container_gateway
 ```
 
 When switching from SQLite to PostgreSQL, if the PostgreSQL database is empty, the SQLite database will be automatically migrated to PostgreSQL.

--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -29,10 +29,13 @@ module Proxy
 
       load_dependency_injection_wirings do |container_instance, settings|
         container_instance.singleton_dependency :database_impl, (lambda do
-          Proxy::ContainerGateway::Database.new(
-            database_backend: settings[:database_backend], sqlite_db_path: settings[:sqlite_db_path],
-            sqlite_timeout: settings[:sqlite_timeout], postgresql_connection_string: settings[:postgresql_connection_string]
-          )
+          if settings[:database_backend] == 'sqlite'
+            connection_string = "sqlite://#{settings[:sqlite_db_path]}?timeout=#{settings[:sqlite_timeout]}"
+          else
+            connection_string = settings[:postgresql_connection_string]
+          end
+
+          Proxy::ContainerGateway::Database.new(connection_string, settings[:sqlite_db_path])
         end)
         container_instance.singleton_dependency :container_gateway_main_impl, (lambda do
           Proxy::ContainerGateway::ContainerGatewayMain.new(

--- a/settings.d/container_gateway.yml.example
+++ b/settings.d/container_gateway.yml.example
@@ -1,10 +1,16 @@
 ---
 :enabled: true
-:pulp_endpoint: 'https://your_pulp_3_server_here.com'
-:pulp_client_ssl_ca: 'CA Cert for authenticating with Pulp'
-:pulp_client_ssl_cert: 'X509 certificate for authenticating with Pulp'
-:pulp_client_ssl_key: 'RSA private key for the Pulp certificate'
-:katello_registry_path: 'Katello container registry suffix, e.g., /v2/'
-:sqlite_db_path: '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
+
+#:pulp_endpoint: 'https://pulp3.example.com'
+#:pulp_client_ssl_ca: '/path/to/ca.pem'
+#:pulp_client_ssl_cert: '/path/to/cert.pem'
+#:pulp_client_ssl_key: '/path/to/key.pem'
+
+#:katello_registry_path: '/v2/'
+
+#:db_connection_string: postgresql:///container_gateway
+
+# Legacy options
+#:sqlite_db_path: '/var/lib/foreman-proxy/smart_proxy_container_gateway.db'
 # Database busy timeout in milliseconds
-:sqlite_timeout: 30000
+#:sqlite_timeout: 30000

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -22,10 +22,7 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
                                                        :sqlite_db_path => 'container_gateway_test.db',
                                                        :database_backend => 'sqlite')
     settings = Proxy::ContainerGateway::Plugin.settings
-    sqlite_db_path = settings[:sqlite_db_path]
-    sqlite_timeout = settings[:sqlite_timeout]
-    @database = Proxy::ContainerGateway::Database.new(sqlite_db_path: sqlite_db_path,
-                                                      sqlite_timeout: sqlite_timeout, database_backend: 'sqlite')
+    @database = Proxy::ContainerGateway::Database.new("sqlite://#{settings[:sqlite_db_path]}?timeout=#{settings[:sqlite_timeout]}")
     @container_gateway_main = Proxy::ContainerGateway::ContainerGatewayMain.new(
       database: @database, pulp_endpoint: settings[:pulp_endpoint],
       pulp_client_ssl_ca: settings[:pulp_client_ssl_ca],

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -19,10 +19,9 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
                                                        :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
                                                        :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
                                                        :pulp_client_ssl_ca => "#{__dir__}/fixtures/mock_pulp_ca.pem",
-                                                       :sqlite_db_path => 'container_gateway_test.db',
-                                                       :database_backend => 'sqlite')
+                                                       :connection_string => 'sqlite://')
     settings = Proxy::ContainerGateway::Plugin.settings
-    @database = Proxy::ContainerGateway::Database.new("sqlite://#{settings[:sqlite_db_path]}?timeout=#{settings[:sqlite_timeout]}")
+    @database = Proxy::ContainerGateway::Database.new(settings[:connection_string])
     @container_gateway_main = Proxy::ContainerGateway::ContainerGatewayMain.new(
       database: @database, pulp_endpoint: settings[:pulp_endpoint],
       pulp_client_ssl_ca: settings[:pulp_client_ssl_ca],

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -7,13 +7,6 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
 
   require 'smart_proxy_container_gateway/container_gateway'
-  Proxy::ContainerGateway::Plugin.load_test_settings(:pulp_endpoint => 'https://test.example.com',
-                                                     :katello_registry_path => '/v2/',
-                                                     :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
-                                                     :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
-                                                     :pulp_client_ssl_ca => "#{__dir__}/fixtures/mock_pulp_ca.pem",
-                                                     :sqlite_db_path => 'container_gateway_test.db',
-                                                     :database_backend => 'sqlite')
   require 'smart_proxy_container_gateway/container_gateway_api'
   require 'smart_proxy_container_gateway/database'
 

--- a/test/container_gateway_backend_test.rb
+++ b/test/container_gateway_backend_test.rb
@@ -8,21 +8,13 @@ class ContainerGatewayBackendTest < Test::Unit::TestCase
   require 'smart_proxy_container_gateway/database'
 
   def setup
-    @database = Proxy::ContainerGateway::Database.new(sqlite_db_path: 'container_gateway_test.db',
-                                                      sqlite_timeout: 30_000, database_backend: 'sqlite')
+    @database = Proxy::ContainerGateway::Database.new('sqlite://')
     @container_gateway_main = Proxy::ContainerGateway::ContainerGatewayMain.new(
       database: @database, pulp_endpoint: 'https://test.example.com',
       pulp_client_ssl_ca: "#{__dir__}/fixtures/mock_pulp_ca.pem",
       pulp_client_ssl_cert: "#{__dir__}/fixtures/mock_pulp_client.crt",
       pulp_client_ssl_key: "#{__dir__}/fixtures/mock_pulp_client.key"
     )
-  end
-
-  def teardown
-    @database.connection[:authentication_tokens].delete
-    @database.connection[:repositories_users].delete
-    @database.connection[:users].delete
-    @database.connection[:repositories].delete
   end
 
   def test_update_repository_list

--- a/test/container_gateway_backend_test.rb
+++ b/test/container_gateway_backend_test.rb
@@ -1,43 +1,20 @@
 require 'test_helper'
-require 'webmock/test_unit'
-require 'rack/test'
 require 'mocha/test_unit'
 
 # rubocop:disable Metrics/AbcSize
 class ContainerGatewayBackendTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
   require 'smart_proxy_container_gateway/container_gateway'
-  Proxy::ContainerGateway::Plugin.load_test_settings(:pulp_endpoint => 'https://test.example.com',
-                                                     :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
-                                                     :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
-                                                     :pulp_client_ssl_ca => "#{__dir__}/fixtures/mock_pulp_ca.pem",
-                                                     :sqlite_db_path => 'container_gateway_test.db',
-                                                     :database_backend => 'sqlite')
   require 'smart_proxy_container_gateway/container_gateway_api'
   require 'smart_proxy_container_gateway/database'
 
-  def app
-    Proxy::ContainerGateway::Api.new
-  end
-
   def setup
-    Proxy::ContainerGateway::Plugin.load_test_settings(:pulp_endpoint => 'https://test.example.com',
-                                                       :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
-                                                       :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
-                                                       :pulp_client_ssl_ca => "#{__dir__}/fixtures/mock_pulp_ca.pem",
-                                                       :sqlite_db_path => 'container_gateway_test.db',
-                                                       :database_backend => 'sqlite')
-    settings = Proxy::ContainerGateway::Plugin.settings
-    sqlite_db_path = settings[:sqlite_db_path]
-    sqlite_timeout = settings[:sqlite_timeout]
-    @database = Proxy::ContainerGateway::Database.new(sqlite_db_path: sqlite_db_path,
-                                                      sqlite_timeout: sqlite_timeout, database_backend: 'sqlite')
+    @database = Proxy::ContainerGateway::Database.new(sqlite_db_path: 'container_gateway_test.db',
+                                                      sqlite_timeout: 30_000, database_backend: 'sqlite')
     @container_gateway_main = Proxy::ContainerGateway::ContainerGatewayMain.new(
-      database: @database, pulp_endpoint: settings[:pulp_endpoint],
-      pulp_client_ssl_ca: settings[:pulp_client_ssl_ca],
-      pulp_client_ssl_cert: settings[:pulp_client_ssl_cert],
-      pulp_client_ssl_key: settings[:pulp_client_ssl_key]
+      database: @database, pulp_endpoint: 'https://test.example.com',
+      pulp_client_ssl_ca: "#{__dir__}/fixtures/mock_pulp_ca.pem",
+      pulp_client_ssl_cert: "#{__dir__}/fixtures/mock_pulp_client.crt",
+      pulp_client_ssl_key: "#{__dir__}/fixtures/mock_pulp_client.key"
     )
   end
 

--- a/test/integration_test.rb
+++ b/test/integration_test.rb
@@ -15,11 +15,9 @@ class ContainerGatewayApiFeaturesTest < Test::Unit::TestCase
   end
 
   def test_features
-    db_path = Tempfile.new.path
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file)
                               .with('container_gateway.yml')
-                              .returns(enabled: true, database_backend: 'sqlite',
-                                       sqlite_db_path: db_path, sqlite_timeout: 30_000,
+                              .returns(enabled: true, db_connection_string: 'sqlite://',
                                        :pulp_client_ssl_cert => "#{__dir__}/fixtures/mock_pulp_client.crt",
                                        :pulp_client_ssl_key => "#{__dir__}/fixtures/mock_pulp_client.key",
                                        :pulp_client_ssl_ca => "#{__dir__}/fixtures/mock_pulp_ca.pem")
@@ -33,11 +31,5 @@ class ContainerGatewayApiFeaturesTest < Test::Unit::TestCase
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:container_gateway])
     assert_equal([], mod['capabilities'])
     assert_equal({}, mod['settings'])
-  ensure
-    begin
-      File.unlink(db_path)
-    rescue Errno::ENOENT => e
-      logger.warn("Failed to delete temporary file: #{e}")
-    end
   end
 end


### PR DESCRIPTION
This prefers a single connection_string setting to be used to connect to a database. This can be anything that Sequel supports. This simplifies configuration and also allows for easy use of an in-memory database in 
testing.

The default value for sqlite_db_path is dropped so that users explicitly need to opt in to a migration if needed.

The example settings file now reflects this.

It also does some further refactoring to clean things up. I had hoped this would be part of 2.0.0. Technically this is breaking (since it changes the settings), so should be 3.0.0.