### PR TITLE
Fixes #37399 - Container gateway needs to send ACCEPT headers from podman to Pulp

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -21,7 +21,7 @@ module Proxy
         )
       end
 
-      def pulp_registry_request(uri)
+      def pulp_registry_request(uri, headers)
         http_client = Net::HTTP.new(uri.host, uri.port)
         http_client.ca_file = @pulp_client_ssl_ca
         http_client.cert = @pulp_client_ssl_cert
@@ -30,30 +30,33 @@ module Proxy
 
         http_client.start do |http|
           request = Net::HTTP::Get.new uri
+          headers.each do |key, value|
+            request[key] = value
+          end
           http.request request
         end
       end
 
-      def ping
+      def ping(headers)
         uri = URI.parse("#{@pulp_endpoint}/pulpcore_registry/v2/")
-        pulp_registry_request(uri).body
+        pulp_registry_request(uri, headers).body
       end
 
-      def manifests(repository, tag)
+      def manifests(repository, tag, headers)
         uri = URI.parse(
           "#{@pulp_endpoint}/pulpcore_registry/v2/#{repository}/manifests/#{tag}"
         )
-        pulp_registry_request(uri)['location']
+        pulp_registry_request(uri, headers)['location']
       end
 
-      def blobs(repository, digest)
+      def blobs(repository, digest, headers)
         uri = URI.parse(
           "#{@pulp_endpoint}/pulpcore_registry/v2/#{repository}/blobs/#{digest}"
         )
-        pulp_registry_request(uri)['location']
+        pulp_registry_request(uri, headers)['location']
       end
 
-      def tags(repository, params = {})
+      def tags(repository, headers, params = {})
         query = "?"
         unless params[:n].nil? || params[:n] == ""
           query = "#{query}n=#{params[:n]}"
@@ -64,7 +67,7 @@ module Proxy
         uri = URI.parse(
           "#{@pulp_endpoint}/pulpcore_registry/v2/#{repository}/tags/list#{query}"
         )
-        pulp_registry_request(uri)
+        pulp_registry_request(uri, headers)
       end
 
       def v1_search(params = {})

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -39,21 +39,21 @@ module Proxy
 
       def ping(headers)
         uri = URI.parse("#{@pulp_endpoint}/pulpcore_registry/v2/")
-        pulp_registry_request(uri, headers).body
+        pulp_registry_request(uri, headers)
       end
 
       def manifests(repository, tag, headers)
         uri = URI.parse(
           "#{@pulp_endpoint}/pulpcore_registry/v2/#{repository}/manifests/#{tag}"
         )
-        pulp_registry_request(uri, headers)['location']
+        pulp_registry_request(uri, headers)
       end
 
       def blobs(repository, digest, headers)
         uri = URI.parse(
           "#{@pulp_endpoint}/pulpcore_registry/v2/#{repository}/blobs/#{digest}"
         )
-        pulp_registry_request(uri, headers)['location']
+        pulp_registry_request(uri, headers)
       end
 
       def tags(repository, headers, params = {})


### PR DESCRIPTION
Without this change, pulling content with the newer pulp-container 2.19 will fail because Pulp will think the container gateway has no manifest acceptance capabilities, thus triggering a 404.

The change also allows errors from Pulp to be returned properly.

To test, try pulling any container content that's on the smart proxy.

To test the proper erroring, try syncing some content and then deleting it in Pulp. This will make the container gateway think that it has repositories synced when it really doesn't, so it should send requests to Pulp for content that doesn't exist.