### PR TITLE
Fixes #37661 - block users properly from pushing content

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -160,6 +160,9 @@ module Proxy
         end
       end
 
+      # Returns:
+      # true if the user is authorized to access the repo, or
+      # false if the user is not authorized to access the repo or if it does not exist
       def authorized_for_repo?(repo_name, user_token_is_valid, username = nil)
         repository = database.connection[:repositories][{ name: repo_name }]
 


### PR DESCRIPTION
Stops users from pushing content:

```
[root@centos9-proxy-devel smart_proxy_container_gateway-3.0.0]# podman  push bef568b8a706 `hostname`/default_organization-precipitation-container_push_view-buttermilk_biscuits-arianna3
Getting image source signatures
Copying blob cd55268b264d [--------------------------------------] 8.0b / 15.6MiB | 1.9 MiB/s
Copying blob d4fc045c9e3a [--------------------------------------] 8.0b / 7.3MiB | 1.8 MiB/s
Copying blob 5f70bf18a086 [--------------------------------------] 8.0b / 1.0KiB | 606.3 KiB/s
WARN[0001] Failed, retrying in 1s ... (1/3). Error: writing blob: initiating layer upload to /v2/default_organization-precipitation-container_push_view-buttermilk_biscuits-arianna3/blobs/uploads/ in centos9-proxy-devel.manicotto.example.com: unsupported: Pushing content is unsupported 
...
```

~Currently blocked by https://github.com/pulp/pulp_container/issues/1703, so to test in the meantime either the content pushing needs to already exist in Pulp (not trigger the 500) or the container gateway needs a hack to throw a 404 always on blob checking.~

~Also, ensure the repo exists in Pulp first. We must throw 401 errors for trying to push to nonexistent repos. Muddies the experience a bit, but that's just how podman works.~

Ensure that the latest pulp-container 2.20 is being used.
Test that all of the endpoints still work properly since general content access was changed.
Test that container push is blocked with a proper message in all cases.

TODO:

- [x] Write tests
