### PR TITLE
Fixes #37705 - 404 v1 search with v2 container clients

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -90,10 +90,10 @@ module Proxy
       end
 
       get '/v1/search/?' do
-        # Checks for podman client and issues a 404 in that case. Podman
+        # Checks for v2 client and issues a 404 in that case. Podman
         # examines the response from a /v1/search request. If the result
         # is a 4XX, it will then proceed with a request to /_catalog
-        if !request.env['HTTP_USER_AGENT'].nil? && request.env['HTTP_USER_AGENT'].downcase.include?('libpod')
+        if request.env['HTTP_DOCKER_DISTRIBUTION_API_VERSION'] == 'registry/2.0'
           halt 404, "not found"
         end
 

--- a/test/container_gateway_api_test.rb
+++ b/test/container_gateway_api_test.rb
@@ -193,6 +193,12 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
     assert last_response.ok?
   end
 
+  def test_v1_search_v2_client
+    header 'DOCKER_DISTRIBUTION_API_VERSION', 'registry/2.0'
+    get '/v1/search'
+    assert last_response.status == 404
+  end
+
   def test_v1_search_with_user
     user_id = @database.connection[:users].insert(name: 'test_user')
     catalog = ["test_repo"]
@@ -210,7 +216,7 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
         }
       ).to_return(:body => foreman_auth_response.to_json)
 
-    header 'HTTP_USER_AGENT', 'notpodman'
+    header 'DOCKER_DISTRIBUTION_API_VERSION', 'registry/1.0'
     # Basic test_user:test_password
     header "AUTHORIZATION", "Basic dGVzdF91c2VyOnRlc3RfcGFzc3dvcmQ="
 
@@ -224,7 +230,7 @@ class ContainerGatewayApiTest < Test::Unit::TestCase
     @container_gateway_main.expects(:catalog).with(nil).returns(catalog)
     catalog.expects(:limit).returns(catalog)
     catalog.expects(:select_map).returns(catalog)
-    header 'HTTP_USER_AGENT', 'notpodman'
+    header 'DOCKER_DISTRIBUTION_API_VERSION', 'registry/1.0'
     get '/v1/search'
     assert last_response.ok?
     assert_equal [{ "description" => "", "name" => "test_repo" }].sort, JSON.parse(last_response.body)["results"].sort


### PR DESCRIPTION
Essentially https://github.com/Katello/katello/pull/11006/files but for the container gateway. For v2 container clients, don't use the old v1 search API endpoint. Instead, throw a 404.

To test, try doing `podman search` with an actual search field. For example: 
```
podman search centos9-proxy-devel.manicotto.example.com/default_organization
```

This should return all container repositories with `default_organization` in the name.

Without this PR, adding anything past the `/` after the hostname causes nothing to get returned.

Test with and without being logged in.