### PR TITLE
Fixes #37925 - translate local time properly for tokens

### DIFF
--- a/lib/smart_proxy_container_gateway/database.rb
+++ b/lib/smart_proxy_container_gateway/database.rb
@@ -5,6 +5,7 @@ module Proxy
       attr_reader :connection
 
       def initialize(connection_string, prior_sqlite_db_path = nil)
+        Sequel.default_timezone = :local
         @connection = Sequel.connect(connection_string)
         if connection_string.start_with?('sqlite://')
           @connection.run("PRAGMA foreign_keys = ON;")


### PR DESCRIPTION
Without setting the Sequel `default_timezone`, the time on tokens from Foreman do not get translated to the local time on the system. This means that the postgres `CURRENT_TIMESTAMP` uses a different timezone from the saved expiry times on tokens.

This PR sets `default_timezone` to `:local` so that the postgres `CURRENT_TIMESTAMP` and the times fetched from the DB  have an agreeing timezone.

To test:
1) On the smart proxy DB, change the timezone to GMT-2:
```
container_gateway=# alter database postgres set TIMEZONE TO 'Etc/GMT-2';
container_gateway=# alter database container_gateway set TIMEZONE TO 'Etc/GMT-2';
container_gateway=# set timezone to 'Etc/GMT-2';
```

2) Also change the system time for good measure:
```
$ timedatectl set-timezone Etc/GMT-2
```

3)  Ensure you're logged out of the smart proxy container registry

4) Log in to the smart proxy container registry

5) See a login error about invalid username/password

6) Patch in my PR, restart foreman-proxy, see that the issue is fixed