### PR TITLE
Add loadbalancer support

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway.rb
@@ -41,7 +41,8 @@ module Proxy
         container_instance.singleton_dependency :container_gateway_main_impl, (lambda do
           Proxy::ContainerGateway::ContainerGatewayMain.new(
             database: container_instance.get_dependency(:database_impl),
-            **settings.slice(:pulp_endpoint, :pulp_client_ssl_ca, :pulp_client_ssl_cert, :pulp_client_ssl_key)
+            **settings.slice(:pulp_endpoint, :pulp_client_ssl_ca, :pulp_client_ssl_cert,
+                             :pulp_client_ssl_key, :client_endpoint)
           )
         end)
       end

--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -46,8 +46,9 @@ module Proxy
           status pulp_response.code.to_i
           body pulp_response.body
         else
-          redirection_location = pulp_response['location']
-          redirect to(redirection_location)
+          redirection_uri = URI(pulp_response['location'])
+          redirection_uri.host = URI(container_gateway_main.client_endpoint).host
+          redirect(redirection_uri.to_s)
         end
       end
 
@@ -236,8 +237,9 @@ module Proxy
           status pulp_response.code.to_i
           body pulp_response.body
         else
-          redirection_location = pulp_response['location']
-          redirect to(redirection_location)
+          redirection_uri = URI(pulp_response['location'])
+          redirection_uri.host = URI(container_gateway_main.client_endpoint).host
+          redirect(redirection_uri.to_s)
         end
       end
 

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -9,17 +9,20 @@ module Proxy
     extend ::Proxy::Log
 
     class ContainerGatewayMain
-      attr_reader :database
+      attr_reader :database, :client_endpoint
 
-      def initialize(database:, pulp_endpoint:, pulp_client_ssl_ca:, pulp_client_ssl_cert:, pulp_client_ssl_key:)
+      # rubocop:disable Metrics/ParameterLists, Layout/LineLength
+      def initialize(database:, pulp_endpoint:, pulp_client_ssl_ca:, pulp_client_ssl_cert:, pulp_client_ssl_key:, client_endpoint: nil)
         @database = database
         @pulp_endpoint = pulp_endpoint
+        @client_endpoint = client_endpoint || pulp_endpoint
         @pulp_client_ssl_ca = pulp_client_ssl_ca
         @pulp_client_ssl_cert = OpenSSL::X509::Certificate.new(File.read(pulp_client_ssl_cert))
         @pulp_client_ssl_key = OpenSSL::PKey::RSA.new(
           File.read(pulp_client_ssl_key)
         )
       end
+      # rubocop:enable Metrics/ParameterLists, Layout/LineLength
 
       def pulp_registry_request(uri, headers)
         http_client = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
When deploying the container gateway behind a load-balancer, the client is given a redirect to the location of the container image as reported by Pulp. This location known by Pulp contains the URL of the smart-proxy and has no knowledge of the load-balancer to send a proper redirect.

This changes introduces a new setting to specification of a loadbalancer when one is in use. If this is provided then the redirect will use that value to calculate the right URL to send back to the client for it to fetch manifests and blobs.

Could we have just used the existing `pulp_endpoint` setting? No. That setting is used by the container gateway itself to make requests to Pulp and if we set it to the load-balancer than all "internal" requests would route all the way out to and back through the load-balancer unnecessarily.

There is some duplicated code between the manifest endpoint and blob handling I intend to look at re-factoring.

The puppet class handling the container gateway, https://github.com/theforeman/puppet-foreman_proxy/blob/master/manifests/plugin/container_gateway.pp, would need to set this using the `foreman_proxy::registration_url` that we currently have users set when using a loadbalancer.