### PR TITLE
Fixes #38144 - Flatpak client unable to do authenticated installs from proxy

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -28,12 +28,6 @@ jobs:
   - job: copr_build
     trigger: pull_request
     targets:
-      rhel-8:
-        additional_modules: "katello:el8,foreman-devel:el8"
-        additional_repos:
-          - https://yum.theforeman.org/releases/nightly/el8/x86_64/
-          - https://yum.theforeman.org/plugins/nightly/el8/x86_64/
-          - https://yum.theforeman.org/katello/nightly/katello/el8/x86_64/
       rhel-9:
         additional_modules: "foreman-devel:el9"
         additional_repos:


### PR DESCRIPTION
Steps to test:

1. Sync a proxy to an environment with some flatpaks with authenticated pull.
2. Register a host to the capsule and run the set up flatpak remote job with server url set to http://capsule.com/pulpcore_registry/.
3. Without running the podman login job on host, try installing an application
4. You'll see a repository not found error.
5. Login with podman login job template
6. Run the flatpak install and it should succeed.

 