### PR TITLE
Bump version to 3.3.0

### DIFF
--- a/lib/smart_proxy_container_gateway/version.rb
+++ b/lib/smart_proxy_container_gateway/version.rb
@@ -1,5 +1,5 @@
 module Proxy
   module ContainerGateway
-    VERSION = '3.2.0'.freeze
+    VERSION = '3.3.0'.freeze
   end
 end


### PR DESCRIPTION
for https://github.com/Katello/smart_proxy_container_gateway/pull/46/