### PR TITLE
Fixes #38530 - proxy the flatpak index

### DIFF
--- a/lib/smart_proxy_container_gateway/container_gateway_api.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_api.rb
@@ -20,6 +20,28 @@ module Proxy
       inject_attr :database_impl, :database
       inject_attr :container_gateway_main_impl, :container_gateway_main
 
+      get '/index/static/?' do
+        # TODO: filter out repositories that are not tied to the (optional) authenticated host
+        # host = <lookup host>
+        # catalog = host_catalog(host)
+
+        # pulp_response = container_gateway_main.flatpak_static_index(translated_headers_for_proxy, params)
+        # if pulp_response.code.to_i >= 400
+        #   status pulp_response.code.to_i
+        #   body pulp_response.body
+        # end
+
+        # pulp_index = JSON.parse(pulp_response.body)
+        # pulp_index["Results"].select! { |result| catalog.include?(result["Name"]) }
+
+        # status 200
+        # body pulp_index.to_json
+
+        pulp_response = container_gateway_main.flatpak_static_index(translated_headers_for_proxy, params)
+        status pulp_response.code.to_i
+        body pulp_response.body
+      end
+
       get '/v1/_ping/?' do
         pulp_response = container_gateway_main.ping(translated_headers_for_proxy)
         status pulp_response.code.to_i

--- a/lib/smart_proxy_container_gateway/container_gateway_main.rb
+++ b/lib/smart_proxy_container_gateway/container_gateway_main.rb
@@ -1,6 +1,7 @@
 require 'net/http'
 require 'uri'
 require 'digest'
+require 'erb'
 require 'smart_proxy_container_gateway/dependency_injection'
 require 'sequel'
 module Proxy
@@ -38,6 +39,14 @@ module Proxy
           end
           http.request request
         end
+      end
+
+      def flatpak_static_index(headers, params = {})
+        uri = URI.parse("#{@pulp_endpoint}/pulpcore_registry/index/static")
+        unless params.empty?
+          uri.query = params.map { |k, v| "#{ERB::Util.url_encode(k.to_s)}=#{ERB::Util.url_encode(v.to_s)}" }.join('&')
+        end
+        pulp_registry_request(uri, headers)
       end
 
       def ping(headers)


### PR DESCRIPTION
Serves the Flatpak index at /index/static.

Also prepares the code to filter the index based on the authenticated client. Includes sample code.

This will require a change to the Apache config: https://github.com/theforeman/puppet-foreman_proxy_content/pull/522